### PR TITLE
Add domain user registration override option

### DIFF
--- a/languages/sign-in-with-google.pot
+++ b/languages/sign-in-with-google.pot
@@ -1,21 +1,21 @@
-# Copyright (C) 2020 North Star Marketing
-# This file is distributed under the same license as the Sign In With Google plugin.
+# Copyright (C) 2021 North Star Marketing
+# This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sign In With Google 1.5.1\n"
+"Project-Id-Version: Sign In With Google 1.6.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sign-in-with-google\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-06-16T15:06:45+00:00\n"
+"POT-Creation-Date: 2021-10-30T15:51:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.4.0\n"
+"X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: sign-in-with-google\n"
 
 #. Plugin Name of the plugin
-#: admin/class-sign-in-with-google-admin.php:119
+#: src/admin/class-sign-in-with-google-admin.php:129
 msgid "Sign In With Google"
 msgstr ""
 
@@ -35,105 +35,133 @@ msgstr ""
 msgid "https://profiles.wordpress.org/northstarmarketing"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:102
+#: src/admin/class-sign-in-with-google-admin.php:112
 msgid "Settings"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:122
+#: src/admin/class-sign-in-with-google-admin.php:132
 msgid "Connect"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:127
+#: src/admin/class-sign-in-with-google-admin.php:137
 msgid "Unlink Account"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:131
+#: src/admin/class-sign-in-with-google-admin.php:141
 msgid "Connect to Google"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:132
+#: src/admin/class-sign-in-with-google-admin.php:142
 msgid "Connect your user profile so you can sign in with Google"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:148
-#: admin/class-sign-in-with-google-admin.php:149
+#: src/admin/class-sign-in-with-google-admin.php:158
+#: src/admin/class-sign-in-with-google-admin.php:159
 msgid "Sign in with Google"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:173
+#: src/admin/class-sign-in-with-google-admin.php:183
 msgid "Client ID"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:181
+#: src/admin/class-sign-in-with-google-admin.php:191
 msgid "Client Secret"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:189
+#: src/admin/class-sign-in-with-google-admin.php:199
 msgid "Default New User Role"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:197
+#: src/admin/class-sign-in-with-google-admin.php:207
 msgid "Restrict To Domain"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:205
+#: src/admin/class-sign-in-with-google-admin.php:215
+msgid "Allow domain user registrations"
+msgstr ""
+
+#: src/admin/class-sign-in-with-google-admin.php:223
 msgid "Custom Login Parameter"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:213
+#: src/admin/class-sign-in-with-google-admin.php:231
 msgid "Show Google Signup Button on Login Form"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:235
+#: src/admin/class-sign-in-with-google-admin.php:256
 msgid "Please paste in the necessary credentials so that we can authenticate your users."
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:295
+#: src/admin/class-sign-in-with-google-admin.php:258
+msgid "Learn More"
+msgstr ""
+
+#: src/admin/class-sign-in-with-google-admin.php:319
 msgid "Enter the domain you would like to restrict new users to or leave blank to allow anyone with a google account. (Separate multiple domains with commas)"
 msgstr ""
 
 #. translators: An example of the required email domain users must have when logging in.
-#: admin/class-sign-in-with-google-admin.php:300
+#: src/admin/class-sign-in-with-google-admin.php:324
 msgid "Entering %1$s will only allow Google users with an @%2$s email address to sign up."
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:359
+#: src/admin/class-sign-in-with-google-admin.php:344
+msgid "If enabled, users with domains in the \"Restrict to Domain\" field will be allowed to register new user accounts even when new user registrations are disabled."
+msgstr ""
+
+#: src/admin/class-sign-in-with-google-admin.php:398
 msgid "Please make sure you have a proper comma separated list of domains."
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:396
+#: src/admin/class-sign-in-with-google-admin.php:435
 msgid "Sign In With Google Settings"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:401
+#: src/admin/class-sign-in-with-google-admin.php:440
 msgid "Save Changes"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:408
+#: src/admin/class-sign-in-with-google-admin.php:445
 msgid "Export Settings"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:415
+#: src/admin/class-sign-in-with-google-admin.php:447
+msgid "Export the plugin settings for this site as a .json file."
+msgstr ""
+
+#: src/admin/class-sign-in-with-google-admin.php:452
 msgid "Export"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:422
+#: src/admin/class-sign-in-with-google-admin.php:459
 msgid "Import Settings"
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:424
+#: src/admin/class-sign-in-with-google-admin.php:461
 msgid "Import the plugin settings from a .json file. This file can be obtained by exporting the settings on another site using the form above."
 msgstr ""
 
-#: admin/class-sign-in-with-google-admin.php:432
+#: src/admin/class-sign-in-with-google-admin.php:469
 msgid "Import"
 msgstr ""
 
 #. translators: The required domain.
-#: admin/class-sign-in-with-google-admin.php:563
+#: src/admin/class-sign-in-with-google-admin.php:577
 msgid "You must have an email with a required domain (<strong>%s</strong>) to log in to this website using Google."
 msgstr ""
 
-#: public/class-sign-in-with-google-public.php:115
+#: src/admin/class-sign-in-with-google-admin.php:640
+msgid "Please upload a valid .json file"
+msgstr ""
+
+#: src/admin/class-sign-in-with-google-admin.php:646
+msgid "Please upload a file to import"
+msgstr ""
+
+#: src/admin/class-sign-in-with-google-admin.php:738
+msgid "Unauthorized"
+msgstr ""
+
+#: src/public/class-sign-in-with-google-public.php:128
 msgid "Log In With Google"
 msgstr ""

--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -211,6 +211,14 @@ class Sign_In_With_Google_Admin {
 		);
 
 		add_settings_field(
+			'siwg_allow_domain_user_registration',
+			__( 'Allow domain user registrations', 'sign-in-with-google' ),
+			array( $this, 'siwg_allow_domain_user_registration' ),
+			'siwg_settings',
+			'siwg_section'
+		);
+
+		add_settings_field(
 			'siwg_custom_login_param',
 			__( 'Custom Login Parameter', 'sign-in-with-google' ),
 			array( $this, 'siwg_custom_login_param' ),
@@ -230,6 +238,7 @@ class Sign_In_With_Google_Admin {
 		register_setting( 'siwg_settings', 'siwg_google_client_secret', array( $this, 'input_validation' ) );
 		register_setting( 'siwg_settings', 'siwg_google_user_default_role' );
 		register_setting( 'siwg_settings', 'siwg_google_domain_restriction', array( $this, 'domain_input_validation' ) );
+		register_setting( 'siwg_settings', 'siwg_allow_domain_user_registration' );
 		register_setting( 'siwg_settings', 'siwg_custom_login_param', array( $this, 'custom_login_input_validation' ) );
 		register_setting( 'siwg_settings', 'siwg_show_on_login' );
 	}
@@ -319,6 +328,21 @@ class Sign_In_With_Google_Admin {
 			?>
 		</p>
 		<?php
+	}
+
+	/**
+	 * Callback function for Allow users with the approved domain register accounts
+	 *
+	 * @since    [NEXT]
+	 */
+	public function siwg_allow_domain_user_registration() {
+
+		echo sprintf(
+			'<input type="checkbox" name="%1$s" id="%1$s" value="1" %2$s /><p class="description">%3$s</p>',
+			'siwg_allow_domain_user_registration',
+			checked( get_option( 'siwg_allow_domain_user_registration' ), true, false ),
+			__( 'If enabled, users with domains in the "Restrict to Domain" field will be allowed to register new user accounts even when new user registrations are disabled.', 'sign-in-with-google' ),
+		);
 	}
 
 	/**
@@ -572,12 +596,13 @@ class Sign_In_With_Google_Admin {
 		}
 
 		$settings = array(
-			'siwg_google_client_id'          => get_option( 'siwg_google_client_id' ),
-			'siwg_google_client_secret'      => get_option( 'siwg_google_client_secret' ),
-			'siwg_google_user_default_role'  => get_option( 'siwg_google_user_default_role' ),
-			'siwg_google_domain_restriction' => get_option( 'siwg_google_domain_restriction' ),
-			'siwg_custom_login_param'        => get_option( 'siwg_custom_login_param' ),
-			'siwg_show_on_login'             => get_option( 'siwg_show_on_login' ),
+			'siwg_google_client_id'               => get_option( 'siwg_google_client_id' ),
+			'siwg_google_client_secret'           => get_option( 'siwg_google_client_secret' ),
+			'siwg_google_user_default_role'       => get_option( 'siwg_google_user_default_role' ),
+			'siwg_google_domain_restriction'      => get_option( 'siwg_google_domain_restriction' ),
+			'siwg_allow_domain_user_registration' => get_option( 'siwg_allow_domain_user_registration' ),
+			'siwg_custom_login_param'             => get_option( 'siwg_custom_login_param' ),
+			'siwg_show_on_login'                  => get_option( 'siwg_show_on_login' ),
 		);
 
 		ignore_user_abort( true );
@@ -730,10 +755,12 @@ class Sign_In_With_Google_Admin {
 	 */
 	protected function find_by_email_or_create( $user_data ) {
 
-		$user = get_user_by( 'email', $user_data->email );
+		$user                           = get_user_by( 'email', $user_data->email );
+		$allow_domain_user_registration = (bool) get_option( 'siwg_allow_domain_user_registration' );
+		$allow_user_registration        = (bool) get_option( 'users_can_register' );
 
-		// Redirect the user if registrations are disabled.
-		if ( false === $user && ! get_option( 'users_can_register' ) ) {
+		// Redirect the user if registrations are disabled and there is no domain user registration override.
+		if ( false === $user && ! $allow_domain_user_registration && ! $allow_user_registration ) {
 			wp_redirect( site_url( 'wp-login.php?registration=disabled' ) );
 			exit;
 		}


### PR DESCRIPTION
This allows users who have an approved domain to bypass the "Anyone
can register" checkbox on the General Settings page.

Closes #71 