### PR TITLE
Functionality to totally replace wp-login page completely by Google Sign-in

### DIFF
--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -869,7 +869,7 @@ class Sign_In_With_Google_Admin {
 		{
 			// Skip only logout action
 			$action = trim( strtolower( $_REQUEST['action'] ) );
-			if ( !in_array( $action, ["logout", "registration"] ) ) {
+			if ( ! in_array( $action, ["logout", "registration"] ) ) {
 				$this->google_auth_redirect();
 			}
 		}

--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -868,7 +868,8 @@ class Sign_In_With_Google_Admin {
 		if ( boolval( get_option( 'siwg_disable_login_page' ) ) ) 
 		{
 			// Skip only logout action
-			if ( trim( strtolower( $_REQUEST['action'] ) ) !== "logout") {
+			$action = trim( strtolower( $_REQUEST['action'] ) );
+			if ( !in_array( $action, ["logout", "registration"] ) ) {
 				$this->google_auth_redirect();
 			}
 		}

--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -868,8 +868,9 @@ class Sign_In_With_Google_Admin {
 		if ( boolval( get_option( 'siwg_disable_login_page' ) ) ) 
 		{
 			// Skip only logout action
-			if ( trim( strtolower( $_REQUEST['action'] ) ) !== "logout")
+			if ( trim( strtolower( $_REQUEST['action'] ) ) !== "logout") {
 				$this->google_auth_redirect();
+			}
 		}
 	}
 }

--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -232,6 +232,14 @@ class Sign_In_With_Google_Admin {
 			'siwg_settings',
 			'siwg_section'
 		);
+	
+		add_settings_field(
+			'siwg_disable_login_page',
+			__( 'Disable WP login page and reditect users to Goolge Sign In', 'sign-in-with-google' ),
+			array( $this, 'siwg_disable_login_page' ),
+			'siwg_settings',
+			'siwg_section'
+		);
 
 		register_setting( 'siwg_settings', 'siwg_google_client_id', array( $this, 'input_validation' ) );
 		register_setting( 'siwg_settings', 'siwg_google_client_secret', array( $this, 'input_validation' ) );
@@ -240,6 +248,7 @@ class Sign_In_With_Google_Admin {
 		register_setting( 'siwg_settings', 'siwg_allow_domain_user_registration' );
 		register_setting( 'siwg_settings', 'siwg_custom_login_param', array( $this, 'custom_login_input_validation' ) );
 		register_setting( 'siwg_settings', 'siwg_show_on_login' );
+		register_setting( 'siwg_settings', 'siwg_disable_login_page' );
 	}
 
 	/**
@@ -361,6 +370,17 @@ class Sign_In_With_Google_Admin {
 	public function siwg_show_on_login() {
 
 		echo '<input type="checkbox" name="siwg_show_on_login" id="siwg_show_on_login" value="1" ' . checked( get_option( 'siwg_show_on_login' ), true, false ) . ' />';
+
+	}
+
+	/**
+	 * Callback function for Show Google Signup Button on Login Form
+	 *
+	 * @since    1.0.0
+	 */
+	public function siwg_disable_login_page() {
+
+		echo '<input type="checkbox" name="siwg_disable_login_page" id="siwg_disable_login_page" value="1" ' . checked( get_option( 'siwg_disable_login_page' ), true, false ) . ' />';
 
 	}
 
@@ -600,6 +620,7 @@ class Sign_In_With_Google_Admin {
 			'siwg_allow_domain_user_registration' => get_option( 'siwg_allow_domain_user_registration' ),
 			'siwg_custom_login_param'             => get_option( 'siwg_custom_login_param' ),
 			'siwg_show_on_login'                  => get_option( 'siwg_show_on_login' ),
+			'siwg_disable_login_page'             => get_option( 'siwg_disable_login_page' ),
 		);
 
 		ignore_user_abort( true );
@@ -834,6 +855,21 @@ class Sign_In_With_Google_Admin {
 		if ( ! empty( $domains ) && ! in_array( $user_domain[1], $domains, true ) ) {
 			wp_redirect( wp_login_url() . '?google_login=incorrect_domain' );
 			exit;
+		}
+	}
+		
+	/**
+	 * Disable Login page & redirect directly to google login
+	 *
+	 * @since 1.3.1
+	 */ 
+	public function check_login_redirection()
+	{
+		if ( boolval( get_option( 'siwg_disable_login_page' ) ) ) 
+		{
+			// Skip only logout action
+			if ( trim( strtolower( $_REQUEST['action'] ) ) !== "logout")
+				$this->google_auth_redirect();
 		}
 	}
 }

--- a/src/includes/class-sign-in-with-google-wpcli.php
+++ b/src/includes/class-sign-in-with-google-wpcli.php
@@ -52,6 +52,9 @@ class Sign_In_With_Google_WPCLI {
 	 * [--show_on_login=<1|0>]
 	 * : Show the "Sign In With Google" button on the login form.
 	 *
+	 * [--disable_login_page=<1|0>]
+	 * : Disable native WP login page at all and redirect users directly to Google Sign-In
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp siwg settings --client_id=XXXXXX.apps.googleusercontent.com
@@ -185,6 +188,19 @@ class Sign_In_With_Google_WPCLI {
 
 		if ( ! $result ) {
 			WP_CLI::warning( 'Skipping Show On Login - Setting already matches' );
+		}
+	}
+
+	/**
+	 * Handles updating siwg_disable_login_page.
+	 *
+	 * @param bool $allow Disable Login page
+	 */
+	private function update_disable_login_page( $disable = 0 ) {
+		$result = update_option( 'siwg_disable_login_page', boolval( $disable ) );
+
+		if ( ! $result ) {
+			WP_CLI::warning( 'Skipping option - Setting already matches' );
 		}
 	}
 

--- a/src/includes/class-sign-in-with-google.php
+++ b/src/includes/class-sign-in-with-google.php
@@ -181,6 +181,7 @@ class Sign_In_With_Google {
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'process_settings_import' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'show_user_profile', $plugin_admin, 'add_connect_button_to_profile' );
+		$this->loader->add_action( 'login_init', $plugin_admin, 'check_login_redirection', 888 );
 
 		if ( isset( $_POST['_siwg_account_nonce'] ) ) {
 			$this->loader->add_action( 'admin_init', $plugin_admin, 'disconnect_account' );


### PR DESCRIPTION
Very useful if site owner wants to disable native WP-logins completely and replace by Google sign-in.