### PR TITLE
Default registration password length as an option

### DIFF
--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -233,6 +233,14 @@ class Sign_In_With_Google_Admin {
 			'siwg_section'
 		);
 
+		add_settings_field(
+			'siwg_password_length',
+			__( 'Default registration password length', 'sign-in-with-google' ),
+			array( $this, 'siwg_password_length' ),
+			'siwg_settings',
+			'siwg_section'
+		);
+
 		register_setting( 'siwg_settings', 'siwg_google_client_id', array( $this, 'input_validation' ) );
 		register_setting( 'siwg_settings', 'siwg_google_client_secret', array( $this, 'input_validation' ) );
 		register_setting( 'siwg_settings', 'siwg_google_user_default_role' );
@@ -240,6 +248,7 @@ class Sign_In_With_Google_Admin {
 		register_setting( 'siwg_settings', 'siwg_allow_domain_user_registration' );
 		register_setting( 'siwg_settings', 'siwg_custom_login_param', array( $this, 'custom_login_input_validation' ) );
 		register_setting( 'siwg_settings', 'siwg_show_on_login' );
+		register_setting( 'siwg_settings', 'siwg_password_length' );
 	}
 
 	/**
@@ -362,6 +371,15 @@ class Sign_In_With_Google_Admin {
 
 		echo '<input type="checkbox" name="siwg_show_on_login" id="siwg_show_on_login" value="1" ' . checked( get_option( 'siwg_show_on_login' ), true, false ) . ' />';
 
+	}
+
+	/**
+	 * Callback function for Default password length
+	 *
+	 * @since    1.0.0
+	 */
+	public function siwg_password_length() {
+		echo '<input name="siwg_password_length" id="siwg_password_length" type="number" value="' . get_option( 'siwg_password_length', 12 ) . '"/>';
 	}
 
 	/**
@@ -600,6 +618,7 @@ class Sign_In_With_Google_Admin {
 			'siwg_allow_domain_user_registration' => get_option( 'siwg_allow_domain_user_registration' ),
 			'siwg_custom_login_param'             => get_option( 'siwg_custom_login_param' ),
 			'siwg_show_on_login'                  => get_option( 'siwg_show_on_login' ),
+			'siwg_password_length'                => get_option( 'siwg_password_length' ),
 		);
 
 		ignore_user_abort( true );
@@ -768,7 +787,7 @@ class Sign_In_With_Google_Admin {
 			return $user;
 		}
 
-		$user_pass    = wp_generate_password( 12 );
+		$user_pass    = wp_generate_password( get_option( 'siwg_password_length', 12 ) );
 		$user_email   = $user_data->email;
 		$first_name   = $user_data->given_name;
 		$last_name    = $user_data->family_name;

--- a/src/includes/class-sign-in-with-google-wpcli.php
+++ b/src/includes/class-sign-in-with-google-wpcli.php
@@ -191,7 +191,7 @@ class Sign_In_With_Google_WPCLI {
 	/**
 	 * Handles updating siwg_password_length.
 	 *
-	 * @param bool $length Set default registration password length.
+	 * @param int $length Set default registration password length.
 	 */
 	private function update_password_length( $length = 12 ) {
 		$result = update_option( 'siwg_password_length', (int) $length );

--- a/src/includes/class-sign-in-with-google-wpcli.php
+++ b/src/includes/class-sign-in-with-google-wpcli.php
@@ -189,6 +189,19 @@ class Sign_In_With_Google_WPCLI {
 	}
 
 	/**
+	 * Handles updating siwg_password_length.
+	 *
+	 * @param bool $length Set default registration password length.
+	 */
+	private function update_password_length( $length = 12 ) {
+		$result = update_option( 'siwg_password_length', (int) $length );
+
+		if ( ! $result ) {
+			WP_CLI::warning( 'Skipping Show On Login - Setting already matches' );
+		}
+	}
+
+	/**
 	 * Sanitize command arguments
 	 *
 	 * @since 1.2.2

--- a/src/includes/class-sign-in-with-google-wpcli.php
+++ b/src/includes/class-sign-in-with-google-wpcli.php
@@ -197,7 +197,7 @@ class Sign_In_With_Google_WPCLI {
 		$result = update_option( 'siwg_password_length', (int) $length );
 
 		if ( ! $result ) {
-			WP_CLI::warning( 'Skipping Show On Login - Setting already matches' );
+			WP_CLI::warning( 'Skipping - Setting already matches' );
 		}
 	}
 


### PR DESCRIPTION
As you said before, I've not changed the default length of 12. However, I've still added option for user-convenience (as in terms of security & etc, it is better user could change the default length to other number, so it will not be always known in advance that domain uses `12` length.).