### PR TITLE
Ability to access & execute the public methods programmatically

### DIFF
--- a/src/includes/class-sign-in-with-google.php
+++ b/src/includes/class-sign-in-with-google.php
@@ -80,6 +80,7 @@ class Sign_In_With_Google {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->register_cli_commands();
 		}
+		add_filter( 'siwg_instance', function() { return $this; } );
 	}
 
 	/**
@@ -174,6 +175,8 @@ class Sign_In_With_Google {
 	private function define_admin_hooks() {
 
 		$plugin_admin = new Sign_In_With_Google_Admin( $this->get_plugin_name(), $this->get_version() );
+		// for extend
+		add_filter( 'siwg_admin_instance', function() use ($plugin_admin) { return $plugin_admin; } );
 
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'settings_api_init' );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'settings_menu_init' );


### PR DESCRIPTION
Eventually, because of huge overhaul needed to use this plugin from core scripts (of app/system) it's inevitably needed to have an access to class instance. Typically, I would expect that when initializing the class within function `sign_in_with_google_run` the instance should have been exposed to global variable (like `$SIWG = new Sign_In_With_Google( '1.6.0' )`) however, as you have chosen to lock that side, there is no other way, other than hooks. This was the only way we could make this plugin to work in our complex app. Now, we can exec  `authenticate_user` or any other functions we need, without re-initializing the **siwg** plugin second time (because WP already initializes is once).