### PR TITLE
Add required params to login_redirect filter

### DIFF
--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -52,7 +52,7 @@ class Sign_In_With_Google_Admin {
 	 *
 	 * @since 1.2.0
 	 * @access private
-	 * @var string $user The user data.
+	 * @var WP_User|false $user The user data.
 	 */
 	private $user;
 

--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -553,12 +553,25 @@ class Sign_In_With_Google_Admin {
 		}
 
 		if ( isset( $state->redirect_to ) && '' !== $state->redirect_to ) {
-			$redirect = $state->redirect_to;
+			$redirect_to = $state->redirect_to;
 		} else {
-			$redirect = admin_url(); // Send users to the dashboard by default.
+			$redirect_to = admin_url(); // Send users to the dashboard by default.
 		}
 
-		wp_redirect( apply_filters( 'siwg_login_redirect', $redirect ) );
+		$requested_redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : '';
+
+		/**
+		 * Filters the login redirect URL.
+		 *
+		 * @since [NEXT]
+		 *
+		 * @param string        $redirect_to           The redirect destination URL.
+		 * @param string        $requested_redirect_to The requested redirect destination URL passed as a parameter.
+		 * @param WP_User|false $user                  WP_User object if login was successful, WP_Error object otherwise.
+		 */
+		$redirect_to = apply_filters( 'login_redirect', $redirect_to, $requested_redirect_to, $user );
+
+		wp_redirect( $redirect_to );
 		exit;
 
 	}

--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -569,7 +569,7 @@ class Sign_In_With_Google_Admin {
 		 * @param string        $requested_redirect_to The requested redirect destination URL passed as a parameter.
 		 * @param WP_User|false $user                  WP_User object if login was successful, WP_Error object otherwise.
 		 */
-		$redirect_to = apply_filters( 'login_redirect', $redirect_to, $requested_redirect_to, $user );
+		$redirect_to = apply_filters( 'login_redirect', $redirect_to, $requested_redirect_to, $user ); // phpcs:ignore
 
 		wp_redirect( $redirect_to );
 		exit;

--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -558,7 +558,7 @@ class Sign_In_With_Google_Admin {
 			$redirect = admin_url(); // Send users to the dashboard by default.
 		}
 
-		wp_redirect( apply_filters( 'login_redirect', $redirect ) ); //phpcs:ignore
+		wp_redirect( apply_filters( 'siwg_login_redirect', $redirect ) );
 		exit;
 
 	}


### PR DESCRIPTION
Removes the core `login_redirect` and replaces it with `siwg_login_redirect` for users to modify the redirect after authentication.

Ideally, the plugin should use the core filter (i.e. `add_filter( 'login_redirect', 'some_function', 10, 1 );`) but this closes #96 for now.