### PR TITLE
Feature: Adds Debug Information to Site Health Info

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -59,7 +59,7 @@ You will need to sign in to the [Google Developer Console](https://console.devel
 
 == Changelog ==
 
-= 1.7.1 (unreleased) =
+= 1.8.1 (unreleased) =
 * Added Debug information for Site Health Info section.
 
 = 1.7.0 =

--- a/README.txt
+++ b/README.txt
@@ -59,6 +59,9 @@ You will need to sign in to the [Google Developer Console](https://console.devel
 
 == Changelog ==
 
+= 1.7.1 (unreleased) =
+* Added Debug information for Site Health Info section.
+
 = 1.7.0 =
 * Add setting that allows users, who have an approved domain, to bypass the "Anyone can register" checkbox on the General Settings page.
 * Update to use login_redirect filter after user authenticates.

--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -758,6 +758,49 @@ class Sign_In_With_Google_Admin {
 	}
 
 	/**
+	 * Adds the Debug Infomation to the WordPress Site Health page.
+	 *
+	 * @hook debug_information
+	 *
+	 * @since 1.7.1
+	 * @param array $info The debug information to be added to the core information page.
+	 *
+	 * @return array $info Updated debug information to be added to the core information page.
+	 */
+	public function add_debug_info_to_site_health( $info ) {
+		$info['siwg-debug-information'] = array(
+			'label'  => __( 'Sign in with Google', 'sign-in-with-google' ),
+			'fields' => array(
+				'version'                             => array(
+					'label' => __( 'Version', 'sign-in-with-google' ),
+					'value' => $this->version,
+				),
+				'siwg_google_user_default_role'       => array(
+					'label' => __( 'Default New User Role', 'sign-in-with-google' ),
+					'value' => get_option( 'siwg_google_user_default_role', 'subscriber' ),
+				),
+				'siwg_google_domain_restriction'      => array(
+					'label' => __( 'Restrict To Domain', 'sign-in-with-google' ),
+					'value' => get_option( 'siwg_google_domain_restriction' ),
+				),
+				'siwg_allow_domain_user_registration' => array(
+					'label' => __( 'Allow Domain User Registrations', 'sign-in-with-google' ),
+					'value' => get_option( 'siwg_allow_domain_user_registration' ),
+				),
+				'siwg_custom_login_param'             => array(
+					'label' => __( 'Custom Login Parameter', 'sign-in-with-google' ),
+					'value' => get_option( 'siwg_custom_login_param' ),
+				),
+				'siwg_show_on_login'                  => array(
+					'label' => __( 'Show Button on Login Form', 'sign-in-with-google' ),
+					'value' => get_option( 'siwg_show_on_login' ),
+				),
+			),
+		);
+		return $info;
+	}
+
+	/**
 	 * Gets a user by email or creates a new user.
 	 *
 	 * @since 1.0.0

--- a/src/admin/class-sign-in-with-google-admin.php
+++ b/src/admin/class-sign-in-with-google-admin.php
@@ -762,7 +762,7 @@ class Sign_In_With_Google_Admin {
 	 *
 	 * @hook debug_information
 	 *
-	 * @since 1.7.1
+	 * @since 1.8.1
 	 * @param array $info The debug information to be added to the core information page.
 	 *
 	 * @return array $info Updated debug information to be added to the core information page.

--- a/src/includes/class-sign-in-with-google.php
+++ b/src/includes/class-sign-in-with-google.php
@@ -181,6 +181,7 @@ class Sign_In_With_Google {
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'process_settings_import' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'show_user_profile', $plugin_admin, 'add_connect_button_to_profile' );
+		$this->loader->add_filter( 'debug_information', $plugin_admin, 'add_debug_info_to_site_health', PHP_INT_MAX, 1 );
 
 		if ( isset( $_POST['_siwg_account_nonce'] ) ) {
 			$this->loader->add_action( 'admin_init', $plugin_admin, 'disconnect_account' );


### PR DESCRIPTION
Adds settings to the debug list in the Site Health Info. This will allow users to use the `Copy to Clipboard` button to dump the plugin settings to help recreate any issues during troubleshooting.

<img width="1792" alt="Screen Shot 2022-04-26 at 9 40 39 PM" src="https://user-images.githubusercontent.com/396942/165421509-f4700250-8ed2-4b9d-8e1c-23daa52d5e8b.png">